### PR TITLE
Updated composer.json for 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.0.*"
+        "symfony/framework-bundle": "2.*,<2.2"
     },
     "autoload": {
         "psr-0": { "WhiteOctober\\BreadcrumbsBundle": "" }


### PR DESCRIPTION
As per @sudent reply in #2. Added 2.1 support (on first PR, had not looked into the BC breaks). Tested and works fine.
