### PR TITLE
- addItem() returns $this in order to allow chaining: addItem()->addItem...

### DIFF
--- a/Model/Breadcrumbs.php
+++ b/Model/Breadcrumbs.php
@@ -12,6 +12,8 @@ class Breadcrumbs implements \Iterator, \ArrayAccess, \Countable
     {
         $b = new SingleBreadcrumb($text, $url);
         $this->breadcrumbs[] = $b;
+        
+        return $this;
     }
 
     public function rewind()


### PR DESCRIPTION
the change proposed in [issue #5](https://github.com/whiteoctober/BreadcrumbsBundle/issues/5)
