### PR TITLE
Out-of-the-box i18n support

### DIFF
--- a/Model/Breadcrumbs.php
+++ b/Model/Breadcrumbs.php
@@ -8,9 +8,9 @@ class Breadcrumbs implements \Iterator, \ArrayAccess, \Countable
 
     private $position = 0;
         
-    public function addItem($text, $url)
+    public function addItem($text, $url, array $translationParameters = array())
     {
-        $b = new SingleBreadcrumb($text, $url);
+        $b = new SingleBreadcrumb($text, $url, $translationParameters);
         $this->breadcrumbs[] = $b;
         
         return $this;

--- a/Model/SingleBreadcrumb.php
+++ b/Model/SingleBreadcrumb.php
@@ -6,10 +6,12 @@ class SingleBreadcrumb
 {
     public $url;
     public $text;
+    public $translationParameters;
 
-    public function __construct($text = "", $url = "")
+    public function __construct($text = "", $url = "", array $translationParameters = array())
     {
         $this->url = $url;
         $this->text = $text;
+        $this->translationParameters = $translationParameters;
     }
 }

--- a/Resources/views/breadcrumbs.html.twig
+++ b/Resources/views/breadcrumbs.html.twig
@@ -2,9 +2,9 @@
   <ul id="wo-breadcrumbs">
     {% for b in wo_breadcrumbs() %}
       {% if loop.last %}
-        <li>{{ b.text }}</li>
+        <li>{{ b.text | trans(b.translationParameters) }}</li>
       {% else %}
-        <li><a href="{{ b.url }}">{{ b.text }}</a></li>
+        <li><a href="{{ b.url }}">{{ b.text | trans(b.translationParameters) }}</a></li>
       {% endif %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
Because overriding the template still didn't enable me to add parameters to a translation string without accessing the translator service directly, I decided to add these modifications.

Usage:

``` php
$breadcrumbs->addItem('contact.details', $url, array('%contact%' => $contact->getName()));
```

To make it complete, translation domain and locale should be added to the Breadcrumbs model, but since I don't use them now this could be something for later.
