### PR TITLE
Trim breadcrumb's texts from surrounding whitespaces

### DIFF
--- a/Resources/views/breadcrumbs.html.twig
+++ b/Resources/views/breadcrumbs.html.twig
@@ -3,7 +3,7 @@
     {% for b in breadcrumbs %}
       <li class="{{ itemClass }}">
         {% if b.url and not loop.last %}<a href="{{ b.url }}">{% endif %}
-        {{ b.text | trans(b.translationParameters, translation_domain, locale) }}
+        {{- b.text | trans(b.translationParameters, translation_domain, locale) -}}
         {% if b.url and not loop.last %}</a>{% endif %}
 
         {% if separator and not loop.last %}


### PR DESCRIPTION
This way, we avoid having links underlined with spaces at the end.
