### PR TITLE
Possibility to set empty separator

### DIFF
--- a/Resources/views/breadcrumbs.html.twig
+++ b/Resources/views/breadcrumbs.html.twig
@@ -6,7 +6,7 @@
         {{- b.text | trans(b.translationParameters, translation_domain, locale) -}}
         {% if b.url and not loop.last %}</a>{% endif %}
 
-        {% if separator and not loop.last %}
+        {% if separator is not null and not loop.last %}
           <span class='{{ separatorClass }}'>{{ separator }}</span>
       {% endif %}
     </li>


### PR DESCRIPTION
Sometimes is need to set empty separator, e.g. it is as background image.
If separator is not needed separator config variable should be set to null.
