### PR TITLE
Add Breadcrumbs::prependItem() method

### DIFF
--- a/Model/Breadcrumbs.php
+++ b/Model/Breadcrumbs.php
@@ -16,6 +16,14 @@ class Breadcrumbs implements \Iterator, \ArrayAccess, \Countable
         return $this;
     }
 
+    public function prependItem($text, $url = "", array $translationParameters = array())
+    {
+        $b = new SingleBreadcrumb($text, $url, $translationParameters);
+        array_unshift($this->breadcrumbs, $b);
+
+        return $this;
+    }
+
     public function addObjectArray(array $objects, $text, $url = "", array $translationParameters = array()) {
         foreach($objects as $object) {
             $itemText = $this->validateArgument($object, $text);

--- a/README.md
+++ b/README.md
@@ -78,6 +78,26 @@ and then in your template:
 The last item in the breadcrumbs collection will automatically be rendered
 as plain text rather than a `<a>...</a>` tag.
 
+The `addItem()` method adds an item to the *end* of the breadcrumbs collection.
+You can use the `prependItem()` method to add an item to the *beginning* of
+the breadcrumbs collection.  This is handy when used in conjunction with
+hierarchical data (e.g. Doctrine Nested-Set).  This example uses categories in
+a product catalog:
+
+    public function yourAction(Category $category)
+    {
+        $breadcrumbs = $this->get("white_october_breadcrumbs");
+
+        $node = $category;
+
+        while ($node) {
+            $breadcrumbs->prependItem($node->getName(), "<category URL>");
+
+            $node = $node->getParent();
+        }
+    }
+
+
 Configuration
 =============
 


### PR DESCRIPTION
As per Issue #36, I have added the Breadcrumbs::prependItem() method to add items to the beginning of the breadcrumbs array.

I have updated the README.md too.

Cheers,

Tom
