### PR TITLE
Add branch alias for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,10 @@
     "autoload": {
         "psr-0": { "WhiteOctober\\BreadcrumbsBundle": "" }
     },
-    "target-dir": "WhiteOctober/BreadcrumbsBundle"
+    "target-dir": "WhiteOctober/BreadcrumbsBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0-dev"
+        }
+    }
 }


### PR DESCRIPTION
The 2.1 branch could possibly be removed, too.