### PR TITLE
Add feature for adding items to breadcrumbs by route name with parameters

### DIFF
--- a/Model/Breadcrumbs.php
+++ b/Model/Breadcrumbs.php
@@ -2,11 +2,18 @@
 
 namespace WhiteOctober\BreadcrumbsBundle\Model;
 
+use Symfony\Component\Routing\RouterInterface;
+
 class Breadcrumbs implements \Iterator, \ArrayAccess, \Countable
 {
     private $breadcrumbs = array();
 
     private $position = 0;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
 
     public function addItem($text, $url = "", array $translationParameters = array())
     {
@@ -22,6 +29,20 @@ class Breadcrumbs implements \Iterator, \ArrayAccess, \Countable
         array_unshift($this->breadcrumbs, $b);
 
         return $this;
+    }
+
+    public function addRouteItem($text, $route, array $parameters = array(), $referenceType = RouterInterface::ABSOLUTE_PATH, array $translationParameters = array())
+    {
+        $url = $this->router->generate($route, $parameters, $referenceType);
+
+        return $this->addItem($text, $url, $translationParameters);
+    }
+
+    public function prependRouteItem($text, $route, array $parameters = array(), $referenceType = RouterInterface::ABSOLUTE_PATH, array $translationParameters = array())
+    {
+        $url = $this->router->generate($route, $parameters, $referenceType);
+
+        return $this->prependItem($text, $url, $translationParameters);
     }
 
     public function addObjectArray(array $objects, $text, $url = "", array $translationParameters = array()) {
@@ -62,6 +83,14 @@ class Breadcrumbs implements \Iterator, \ArrayAccess, \Countable
             $this->addObjectTree($itemParent, $text, $url, $parent, $translationParameters, $firstPosition);
         }
         return $this;
+    }
+
+    /**
+     * @param RouterInterface $router
+     */
+    public function setRouter(RouterInterface $router)
+    {
+        $this->router = $router;
     }
 
     public function rewind()

--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ public function yourAction(Category $category)
 }
 ```
 
+If you do not want generating url manually, you can easily to add breadcrumbs items
+passing only route name with required parameters using `addRouteItem()` and `prependRouteItem()` methods:
+
+``` php
+public function yourAction()
+{
+    $breadcrumbs = $this->get("white_october_breadcrumbs");
+    
+    // Pass "_demo" route name without any parameters
+    $breadcrumbs->addRouteItem("Demo", "_demo");
+
+    // Pass "_demo_hello" route name with parameters
+    $breadcrumbs->addRouteItem("Hello Breadcrumbs", "_demo_hello", array(
+        'name' => 'Breadcrumbs',
+    ));
+
+    // Add "homepage" route link to begin of breadcrumbs
+    $breadcrumbs->prependRouteItem("Home", "homepage");
+}
+```
+
 Configuration
 =============
 

--- a/Resources/config/breadcrumbs.xml
+++ b/Resources/config/breadcrumbs.xml
@@ -6,7 +6,11 @@
     <services>
 
         <!-- Our service, for controllers -->
-        <service id="white_october_breadcrumbs" class="WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs"></service>
+        <service id="white_october_breadcrumbs" class="WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs">
+            <call method="setRouter">
+                <argument type="service" id="router" />
+            </call>
+        </service>
 
         <!-- Templating helper -->
         <service id="white_october_breadcrumbs.helper" class="WhiteOctober\BreadcrumbsBundle\Templating\Helper\BreadcrumbsHelper">


### PR DESCRIPTION
Hey @richsage!

There is PR on https://github.com/whiteoctober/BreadcrumbsBundle/issues/38 issue from @tomhv.

Quick overview of new functionality:

``` php
public function yourAction()
{
    $breadcrumbs = $this->get("white_october_breadcrumbs");

    // Pass "_demo" route name without any parameters
    $breadcrumbs->addRouteItem("Demo", "_demo");

    // Pass "_demo_hello" route name with parameters
    $breadcrumbs->addRouteItem("Hello Breadcrumbs", "_demo_hello", array(
        'name' => 'Breadcrumbs',
    ));

    // Add "homepage" route link to begin of breadcrumbs
    $breadcrumbs->prependRouteItem("Home", "homepage");
}
```

Was added few functional methods with optional dependency injection of [router](Symfony\Component\Routing\RouterInterface), so I vote :+1: for increase the minor version to `1.1.0`.