### PR TITLE
Drop data-vocabulary.org outdated schema for schema.org

### DIFF
--- a/Resources/views/breadcrumbs.html.twig
+++ b/Resources/views/breadcrumbs.html.twig
@@ -1,15 +1,16 @@
 {% if wo_breadcrumbs()|length %}
     {%- spaceless -%}
-        <ol id="{{ listId }}" class="{{ listClass }}" itemscope itemtype="http://data-vocabulary.org/Breadcrumb">
+        <ol id="{{ listId }}" class="{{ listClass }}" itemscope itemtype="http://schema.org/BreadcrumbList">
             {% for b in breadcrumbs %}
-                <li{% if itemClass is defined and itemClass|length %} class="{{ itemClass }}"{% endif %}{% if not(loop.first) %} itemprop="child"{% endif %}>
+                <li{% if itemClass is defined and itemClass|length %} class="{{ itemClass }}"{% endif %} itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
                     {% if b.url and not loop.last %}
-                        <a href="{{ b.url }}" itemprop="url"{% if linkRel is defined and linkRel|length %} rel="{{ linkRel }}"{% endif %}>
+                        <a href="{{ b.url }}" itemprop="item"{% if linkRel is defined and linkRel|length %} rel="{{ linkRel }}"{% endif %}>
                     {% endif %}
-                            <span itemprop="title">{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}</span>
+                            <span itemprop="name">{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}</span>
                     {% if b.url and not loop.last %}
                         </a>
                     {% endif %}
+                    <meta itemprop="position" content="{{ loop.index }}" />
 
                     {% if separator is not null and not loop.last %}
                         <span class='{{ separatorClass }}'>{{ separator }}</span>


### PR DESCRIPTION
Hi,
We are now using the [breadcrumb list's schema of schema.org](http://schema.org/BreadcrumbList).

Have a nice day.