### PR TITLE
Ensure templating component is installed and configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,16 @@ Installation
     white_october_breadcrumbs: ~
     ```
     
-That's  it for basic configuration. For more options check the [Configuration](#configuration) section.
+4. Configure templating for your application if you haven't already.  For example:
+
+    ```yaml
+    # app/config/config.yml (Symfony <=3)
+    # config/packages/framework.yaml (Symfony 4)
+    templating:
+        engines: ['twig']
+    ```
+    
+That's it for basic configuration. For more options check the [Configuration](#configuration) section.
 
 Usage
 =====

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.0|~3.0|^4.0"
+        "symfony/framework-bundle": "~2.0|~3.0|^4.0",
+        "symfony/templating": "^3.4|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4",
-        "symfony/templating": "^3.4|^4.0",
         "symfony/browser-kit": "~2.7|~3.0|^4.0"
     },
     "autoload": {


### PR DESCRIPTION
**Add note about configuring templating for application**

This fixes #85 in Symfony < 4 (Symfony 4 requires the composer changes too)

**Make symfony/templating required for regular install, not just dev**

In Symfony 4, it won't come in with the framework bundle (see discussion [here](https://github.com/whiteoctober/BreadcrumbsBundle/pull/82#discussion_r170304176))