### PR TITLE
Fix installation instructions for Symfony <= 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Installation
 
     ```yaml
     # app/config/config.yml (Symfony <=3)
+    framework:
+        templating:
+            engines: ['twig']
+    
     # config/packages/framework.yaml (Symfony 4)
     templating:
         engines: ['twig']


### PR DESCRIPTION
With Symfony <= 3, the `templating.engines` node should be inserted inside of the `framework` key.