### PR TITLE
Add support for template overrides with bundles path

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,7 +27,7 @@ class Configuration implements ConfigurationInterface
                 scalarNode("linkRel")->defaultValue("")->end()->
                 scalarNode("locale")->defaultNull()->end()->
                 scalarNode("translation_domain")->defaultNull()->end()->
-                scalarNode("viewTemplate")->defaultValue("WhiteOctoberBreadcrumbsBundle::microdata.html.twig")->end()->
+                scalarNode("viewTemplate")->defaultValue("@WhiteOctoberBreadcrumbsBundle/microdata.html.twig")->end()->
             end()
         ;
 

--- a/DependencyInjection/WhiteOctoberBreadcrumbsExtension.php
+++ b/DependencyInjection/WhiteOctoberBreadcrumbsExtension.php
@@ -35,10 +35,10 @@ class WhiteOctoberBreadcrumbsExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if($config['viewTemplate'] === 'WhiteOctoberBreadcrumbsBundle::breadcrumbs.html.twig') {
+        if(in_array($config['viewTemplate'], array('WhiteOctoberBreadcrumbsBundle::breadcrumbs.html.twig', 'WhiteOctoberBreadcrumbsBundle::microdata.html.twig'))) {
             trigger_error(
                 'Using viewTemplate "'.$config['viewTemplate'].'"" is deprecated and should be replaced by ' .
-                '"WhiteOctoberBreadcrumbsBundle::microdata.html.twig"',
+                '"@WhiteOctoberBreadcrumbsBundle/microdata.html.twig"',
                 E_USER_DEPRECATED
             );
         }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Installation
     # app/config/config.yml
     white_october_breadcrumbs: ~
     ```
-    
+
 4. Configure templating for your application if you haven't already.  For example:
 
     ```yaml
@@ -47,7 +47,7 @@ Installation
     templating:
         engines: ['twig']
     ```
-    
+
 That's it for basic configuration. For more options check the [Configuration](#configuration) section.
 
 Usage
@@ -139,8 +139,10 @@ white_october_breadcrumbs:
     linkRel:            ''
     locale:             ~ # defaults to null, so the default locale is used
     translation_domain: ~ # defaults to null, so the default domain is used
-    viewTemplate:       'WhiteOctoberBreadcrumbsBundle::microdata.html.twig'
+    viewTemplate:       '@WhiteOctoberBreadcrumbsBundle/microdata.html.twig'
 ```
+
+> **NOTE:** Change `viewTemplate` if you need to use a different built-in view or your own custom view
 
 These can also be passed as parameters in the view when rendering the
 breadcrumbs - for example:
@@ -227,14 +229,19 @@ There are two methods for doing this.
 
 1. You can override the template used by copying the
     `Resources/views/microdata.html.twig` file out of the bundle and placing it
-    into `app/Resources/WhiteOctoberBreadcrumbsBundle/views`, then customising
+    into `app/Resources/WhiteOctoberBreadcrumbsBundle/views` (Symfony <=3) or `templates/bundles/WhiteOctoberBreadcrumbsBundle` (Symfony 4), then customising
     as you see fit. Check the [Overriding bundle templates][1] documentation section
     for more information.
 
 2. Use the `viewTemplate` configuration parameter:
     
     ``` jinja
+    {# Symfony <=3 #}
     {{ wo_render_breadcrumbs({ viewTemplate: "YourOwnBundle::yourBreadcrumbs.html.twig" }) }}
+    ```
+    ``` jinja
+    {# Symfony 4 #}
+    {{ wo_render_breadcrumbs({ viewTemplate: "path/to/yourBreadcrumbs.html.twig" }) }}
     ```
 > **NOTE:** If you want to use the JSON-LD format, there's already an existing template 
 at `WhiteOctoberBreadcrumbsBundle::json-ld.html.twig`. Just set this template as the value for 

--- a/Resources/views/breadcrumbs.html.twig
+++ b/Resources/views/breadcrumbs.html.twig
@@ -1,1 +1,1 @@
-{% include "WhiteOctoberBreadcrumbsBundle::microdata.html.twig" %}
+{% include "@WhiteOctoberBreadcrumbsBundle/microdata.html.twig" %}

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.0|~3.0|^4.0",
-        "symfony/templating": "^3.4|^4.0"
+        "symfony/framework-bundle": "^2.3|^3.0|^4.0",
+        "symfony/templating": "^2.3|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4",
-        "symfony/browser-kit": "~2.7|~3.0|^4.0"
+        "symfony/browser-kit": "^2.3|^3.0|^4.0"
     },
     "autoload": {
         "psr-0": { "WhiteOctober\\BreadcrumbsBundle": "" }


### PR DESCRIPTION
I'm working with Symfony 4, and tried to override the template using the method they say in the docs, and it wasn't working.
Being new to the whole Symfony framework was a good chance for me to go and try to make it work.
So I did, it works with both files in the `templates/bundles/WhiteOctoberBreadcrumbsBundle/` folder and with custom `viewTemplate` passed to the `wo_render_breadcrumbs` function.

I only tested it with Symfony 4, I tried with Symfony 3 but for some reason my test project wasn't loading, and I didn't want to lose too much time making version 3.4 to work.

Cheers.