### PR TITLE
Fix missing URL for last item when provided

### DIFF
--- a/Resources/views/microdata.html.twig
+++ b/Resources/views/microdata.html.twig
@@ -9,6 +9,8 @@
                         <span itemprop="name">{% if b.translate is defined and b.translate == true %}{{- b.text | trans(b.translationParameters, translation_domain, locale) -}}{% else %}{{- b.text -}}{% endif %}</span>
                         {% if b.url and not loop.last %}
                     </a>
+                    {% elseif b.url %}
+                        <meta itemprop="item" content="{{ b.url }}" />
                     {% endif %}
                     <meta itemprop="position" content="{{ loop.index }}" />
 


### PR DESCRIPTION
Hello

Thanks for this usefull extension we like on Mapado.com :)

While testing our pages with Google structured data testing tool, we have noticed an error as the last element is missing the "item" value (i.e. the URL).

You can see the error raised on this example: https://search.google.com/structured-data/testing-tool/u/0/?url=https%3A%2F%2Fwww.mapado.com%2Fmanhattan%2Fonce-on-this-island-3

I don't know if this is in the schema.org "official rules" that the "item" value is mandatory in such case, but as it triggs an error on Google tool, I propose to fix this with a <meta> field add when URL is available for the last element of the breadcrumb.

Thanks in advance for the review! 

Nicolas