### PR TITLE
Change EngineTemplating to Twig for fix Symfony 4.3 deprecations

### DIFF
--- a/Resources/config/breadcrumbs.xml
+++ b/Resources/config/breadcrumbs.xml
@@ -17,7 +17,7 @@
 
         <!-- Templating helper -->
         <service id="white_october_breadcrumbs.helper" class="WhiteOctober\BreadcrumbsBundle\Templating\Helper\BreadcrumbsHelper" public="true">
-            <argument type="service" id="templating" />
+            <argument type="service" id="twig" />
             <argument type="service" id="white_october_breadcrumbs" />
             <argument>%white_october_breadcrumbs.options%</argument>
             <tag name="templating.helper" alias="breadcrumbs" />

--- a/Templating/Helper/BreadcrumbsHelper.php
+++ b/Templating/Helper/BreadcrumbsHelper.php
@@ -3,13 +3,13 @@
 namespace WhiteOctober\BreadcrumbsBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
 use WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs;
 
 class BreadcrumbsHelper extends Helper
 {
     /**
-     * @var EngineInterface
+     * @var Environment
      */
     protected $templating;
 
@@ -24,11 +24,11 @@ class BreadcrumbsHelper extends Helper
     protected $options = array();
 
     /**
-     * @param \Symfony\Component\Templating\EngineInterface $templating
+     * @param \Twig\Environment $templating
      * @param \WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs $breadcrumbs
      * @param array $options The default options load from config file
      */
-    public function __construct(EngineInterface $templating, Breadcrumbs $breadcrumbs, array $options)
+    public function __construct(Environment $templating, Breadcrumbs $breadcrumbs, array $options)
     {
         $this->templating  = $templating;
         $this->breadcrumbs = $breadcrumbs;


### PR DESCRIPTION
Hello, in symfony 4.3 the templating component is deprecated. To fix this the templating engine should be change to twig. 

https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration